### PR TITLE
Normalize line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,12 @@
+###############################################################################
+# Set default behavior to automatically normalize line endings.
+###############################################################################
+* text=auto
+
+# Ensure shell scripts use LF line endings (linux only accepts LF)
+*.sh eol=lf
+*.ps1 eol=lf
+
 ManagedGitLib.ExtendedTests/commit* binary
 ManagedGitLib.Tests/commit-ab39e8acac105fa0db88514f259341c9f0201b22 binary
 ManagedGitLib.Tests/commit-ab39e8acac105fa0db88514f259341c9f0201b22-message binary


### PR DESCRIPTION
Apparently all files were commited with LF line endings already, so no other files had to be changed as part of this. But the nice part about being explicit like this is now it'll behave on every git clone rather than depend on the machine settings on each clone to match the author's.

Closes #3 